### PR TITLE
Modify align process

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -28,4 +28,4 @@ You can do the either of the following to modify the parameters of the pipeline:
     - Example: `bash run_nf.sh --fasta_file /path/to/fasta/file`
 
 ## Tips
-- If "*align*" is present in the fasta file name then the workflow will not align the fasta file.
+- If "*aligned*" is present in the fasta file name then the workflow will not align the fasta file.

--- a/.github/README.md
+++ b/.github/README.md
@@ -9,6 +9,8 @@ This is a workflow for the Freyja Pathogen pipeline.
         - [Nextflow](https://www.nextflow.io/docs/latest/getstarted.html)
     - Install inside conda environment:
         - [PhyCLIP](https://github.com/alvinxhan/PhyCLIP)
+        > **Warning**
+            > The [PhyCLIP](https://github.com/alvinxhan/PhyCLIP) package requires Gurobi to be installed. You will require a license **(Cannot be used in a docker container)** to use Gurobi. If you do not have a license, you can use the free [Gurobi Academic License](https://www.gurobi.com/academia/academic-program-and-licenses/).
 2. Clone this repository.
     - `git clone https://github.com/gp201/Freyja_pathogen_workflow.git`
 3. Enter the cloned repository.

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,45 +1,29 @@
 # Freyja Pathogen Workflow
 
-This is a workflow for the Freyja Pathogen pipeline. It is designed to be run using docker.
-
+This is a workflow for the Freyja Pathogen pipeline.
 
 ## Installation
 1. Install the following software:
     - [Conda](https://docs.conda.io/en/latest/miniconda.html)
     - Install outside conda environment:
         - [Nextflow](https://www.nextflow.io/docs/latest/getstarted.html)
-        - [TreeTime](https://treetime.readthedocs.io/en/latest/installation.html)
-        - [MAFFT](https://mafft.cbrc.jp/alignment/software/)
     - Install inside conda environment:
-        - [usher]()
-        - [augur]()
-        - [PhyCLIP]()
-    > **Note**  
-    > [setup.sh](/setup.sh) installs all the **conda** packages listed above.  
-    > It is recommended to run this script to install all the required packages.  
-    > If you want to install the packages run `bash setup.sh`.
+        - [PhyCLIP](https://github.com/alvinxhan/PhyCLIP)
 2. Clone this repository.
     - `git clone https://github.com/gp201/Freyja_pathogen_workflow.git`
 3. Enter the cloned repository.
     - `cd Freyja_pathogen_workflow`
-4. Make the python scripts executable.
-    - `chmod +x bin/*`
-4. Run the nextflow pipeline
-    - `nextflow -C configs/nextflow.config run process_pathogen.nf`
+4. Run `bash run_nf.sh` to run the pipeline.
     - Modify the [nextflow.config](/configs/nextflow.config) file to change the parameters of the pipeline.
-> **Warning**
-> Edit conda env location in the `nextflow.config` file.
+    > **Warning**
+    > Edit conda env location for `phyclip` in the `nextflow.config` file.
 
-## Installation
-1. Clone this repository
-2. Install docker
-3. Run `bash start_docker.sh {mount_loc}` to start the docker container.
-    - `{mount_loc}` is the location of the directory you want to mount to the docker container. This is where the input and output files will be stored.
-4. Run `bash setup.sh` to install the necessary packages.
-> **Warning**
-> The [PhyCLIP](https://github.com/alvinxhan/PhyCLIP) package requires Gurobi
-> to be installed. You will require a license **(Cannot be used in a docker container)** to use Gurobi. You will need to get a special license for docker containers.
-5. Run `bash run_nf.sh` to run the pipeline. The following steps will run:
+## Modify parameters
+You can do the either of the following to modify the parameters of the pipeline:
+1. Edit the [nextflow.config](/configs/nextflow.config) file.
+2. Run the pipeline with the parameters you want to change.
+    - Example: `bash run_nf.sh [[params]]`
+    - Example: `bash run_nf.sh --fasta_file /path/to/fasta/file`
 
-> **Note**
-> Edit the `nextflow.config` file to change the parameters for the pipeline.
+## Tips
+- If "*align*" is present in the fasta file name then the workflow will not align the fasta file.

--- a/configs/nextflow.config
+++ b/configs/nextflow.config
@@ -4,8 +4,6 @@ params {
     metadata_file = "/data/example_dates.tsv"
     reference = '/NA'
     tree_file = '/data/example_tree.nwk'
-    align_to_reference = false
-    align_mode = 'mafft'
     skip_clade_annotations = false
     threads = 15
     iqtree_nucleotide_model = "MFP"

--- a/process_pathogen.nf
+++ b/process_pathogen.nf
@@ -18,8 +18,8 @@ process align {
         path "aligned.fasta", emit: aligned_fasta_file
     script:
         """
-        // if "align" is present in any part of the file name. skip alignment.
-        if [[ $fasta == *align* ]]
+        // if "aligned" is present in any part of the file name. skip alignment.
+        if [[ $fasta == *aligned* ]]
         then
             cp $fasta aligned.fasta
         else

--- a/process_pathogen.nf
+++ b/process_pathogen.nf
@@ -17,18 +17,14 @@ process align {
     output:
         path "aligned.fasta", emit: aligned_fasta_file
     script:
-    if (params.align_mode == 'mafft')
-        if (params.align_to_reference == false)
-            """
-            mafft --auto --thread $params.threads $fasta > aligned.fasta
-            """
-        else
-            """
-            mafft --auto --thread $params.threads --addfragments $fasta $ref_seq > aligned.fasta
-            """
-    else if( params.align_mode == 'minimap2' )
         """
-        minimap2 -a $ref_seq $fasta | gofasta sam toMultiAlign  > aligned.fasta
+        // if "align" is present in any part of the file name. skip alignment.
+        if [[ $fasta == *align* ]]
+        then
+            cp $fasta aligned.fasta
+        else
+            mafft --auto --thread $params.threads --addfragments $fasta $ref_seq > aligned.fasta
+        fi
         """
     stub:
         """


### PR DESCRIPTION
This PR does the following:
- Removes the `align_to_reference` and `align_mode` since we only use align to reference and mafft to align. We can re-introduce the options when required.
- Update align process to allow users to skip the align step if the keyword "aligned" is present in the fasta file name.
- Update the README